### PR TITLE
Fix requirements import to include -r

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-- requirements.txt
+-r requirements.txt
 
 ipython>=4.2.0
 django-dotenv==1.4.1


### PR DESCRIPTION
Fix missing `-r` flag to include the base `requirements.txt` file. Last line appears to be modified because of the previously missing terminating newline character.