### PR TITLE
Revert "Switch from pycodestyle to flake8"

### DIFF
--- a/interface/linters.py
+++ b/interface/linters.py
@@ -3,11 +3,11 @@ import subprocess
 from django.apps import apps
 
 
-FLAKE8 = 'flake8'
+PYCODESTYLE = 'pycodestyle'
 ESLINT = 'eslint'
 
 LINTER_CHOICES = (
-    (FLAKE8, FLAKE8),
+    (PYCODESTYLE, PYCODESTYLE),
     (ESLINT, ESLINT)
 )
 
@@ -19,15 +19,15 @@ def lint(build):
         result = linter(build)
         return True if result and passing else False
 
-    passing = run_linter(flake8)
+    passing = run_linter(pycodestyle)
     # passing = run_linter(eslint)
 
     return passing
 
 
-def flake8(build):
+def pycodestyle(build):
     try:
-        output = subprocess.check_output(['flake8', build.directory])
+        output = subprocess.check_output(['pycodestyle', build.directory])
         passing = True
     except subprocess.CalledProcessError as e:
         output = e.output
@@ -35,7 +35,7 @@ def flake8(build):
 
     output = output.decode("utf-8").replace(build.directory, '')
     Result = apps.get_model('interface', 'Result')
-    Result.objects.create(build=build, linter=FLAKE8, output=output)
+    Result.objects.create(build=build, linter=PYCODESTYLE, output=output)
 
     return passing
 

--- a/interface/templates/base.html
+++ b/interface/templates/base.html
@@ -4,7 +4,7 @@
     <title>{% if DEBUG %}[DEBUG] {% endif %}{% block title %}{% endblock %}</title>
     <meta charset="UTF-8">
     <meta name="description" content="Free automated code linting">
-    <meta name="keywords" content="code,lint,linty,pep8,pycodestyle,flake8,eslint,ci">
+    <meta name="keywords" content="code,lint,linty,pep8,pycodestyle,eslint,ci">
     <meta name="author" content="https://github.com/birkholz">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/semantic.min.css">
     <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}">

--- a/interface/templates/index.html
+++ b/interface/templates/index.html
@@ -5,7 +5,7 @@
     <title>{% if DEBUG %}[DEBUG] {% endif %}Linty - Free code linting</title>
     <meta charset="UTF-8">
     <meta name="description" content="Free automated code linting">
-    <meta name="keywords" content="code,lint,linty,pep8,pycodestyle,flake8,eslint,ci">
+    <meta name="keywords" content="code,lint,linty,pep8,pycodestyle,eslint,ci">
     <meta name="author" content="https://github.com/birkholz">
     <link rel="stylesheet" type="text/css"
           href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.8/semantic.min.css">

--- a/interface/tests.py
+++ b/interface/tests.py
@@ -27,7 +27,7 @@ class LintTestCase(TestCase):
         )
         self.result = Result.objects.create(
             build=self.build,
-            linter=linters.FLAKE8,
+            linter=linters.PYCODESTYLE,
             output='/interface/views.py:34:1: E303 too many blank lines (3)'
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 dj-database-url==0.4.1
 Django==1.10
 requests==2.11.0
-flake8==3.0.4
 -e git+https://github.com/PyCQA/pycodestyle.git#egg=pycodestyle
 psycopg2==2.6.2
 python-social-auth==0.2.19


### PR DESCRIPTION
Reverts ZeroCater/linty#78

Reverting because flake8 isn't using the newer version of pycodestyle, and so it isn't reading setup.cfg properly

Also because this: https://www.lintyapp.com/build/1157