### PR TITLE
Ignore E305 until fixed upstream

### DIFF
--- a/interface/linters.py
+++ b/interface/linters.py
@@ -32,7 +32,7 @@ def lint(build):
 def pycodestyle(build, cwd):
     # TODO: Allow the user to specify their preferred version of pycodestyle
     try:
-        output = subprocess.check_output(['pycodestyle', cwd])
+        output = subprocess.check_output(['pycodestyle', cwd, '--ignore=E305'])
         passing = True
     except subprocess.CalledProcessError as e:
         output = e.output


### PR DESCRIPTION
Resolves #91 

This should prevent false negatives until the issue with Pycodestyle is fixed.