### PR TITLE
Add .slugignore to exclude files from deployment

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,8 @@
+.env.sample
+.gitignore
+circle.yml
+LICENSE
+README.md
+requirements.dev.txt
+# Don't apply linty's rules to other projects
+setup.cfg

--- a/interface/linters.py
+++ b/interface/linters.py
@@ -32,7 +32,7 @@ def lint(build):
 def pycodestyle(build, cwd):
     # TODO: Allow the user to specify their preferred version of pycodestyle
     try:
-        output = subprocess.check_output(['pycodestyle', cwd, '--ignore=E305'])
+        output = subprocess.check_output(['pycodestyle', cwd])
         passing = True
     except subprocess.CalledProcessError as e:
         output = e.output


### PR DESCRIPTION
@kavdev I think this will finally close #72. Linty will no longer deploy with its own `setup.cfg`, which means all projects will have a blank list of excludes unless they provide their own. I've also removed the hardcoded `E305` exclusion, now that pycodestyle `2.2.0` has resolved the bug that caused it to always fail. I took a list at your latest commits with these changes, and it looks like you have a couple legit E305 failures. So once this goes live, you might want to hit "re-run" and take a look.