### PR TITLE
Replace npm lint with eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,3 +1,20 @@
 {
-
+  "name": "linty",
+  "version": "1.0.0",
+  "description": "javascript linters for linty",
+  "engines": {
+    "node": "6.6.0"
+  },
+  "dependencies": {
+    "eslint": "^3.7.1",
+    "eslint-config-airbnb": "^11.1.0",
+    "eslint-config-littlebits": "^0.5.1",
+    "eslint-config-standard": "^6.0.0",
+    "eslint-config-semistandard": "^7.0.0",
+    "eslint-plugin-import": "^1.15.0",
+    "eslint-plugin-jsx-a11y": "^2.2.2",
+    "eslint-plugin-promise": "^3.3.0",
+    "eslint-plugin-react": "^6.2.2",
+    "eslint-plugin-standard": "^2.0.0"
+  }
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -29,6 +29,9 @@ body > .ui.text.container {
 textarea.output {
     font-family: monospace;
     font-size: 12px !important;
+    white-space: pre;
+    overflow-wrap: normal;
+    overflow-x: scroll;
 }
 .left.aligned.button {
     float: left;


### PR DESCRIPTION
The current solution for linting via `npm run lint` isn't secure, as it allows arbitrary code execution. This replaces it with a global `eslint` installation. At the moment, eslint is used for all node applications. In the future, we could provide support for other JS linters via some sort of config. 